### PR TITLE
Fix logging side effects

### DIFF
--- a/utils/logging.py
+++ b/utils/logging.py
@@ -1,5 +1,5 @@
-import argparse
 import logging
+import os
 import sys
 
 # ANSI escape sequences for colors
@@ -66,14 +66,9 @@ def get_logger(name=None):
     """
     return logging.getLogger(name)
 
-# Parse command-line arguments for log level
-parser = argparse.ArgumentParser(description="Colored Logging Example")
-parser.add_argument("--log-level", default="INFO",
-                    help="Set logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)")
-args = parser.parse_args()
-
-# Initialize logging with the chosen level
-logger = setup_logging(args.log_level)
+# Initialize logging using environment variable or default INFO
+_log_level = os.getenv("LOG_LEVEL", "INFO")
+logger = setup_logging(_log_level)
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
## Summary
- fix `utils.logging` so it no longer parses CLI args on import

## Testing
- `python -m py_compile agents/run.py utils/logging.py`
- `python agents/run.py FileConverter "test" --log-level DEBUG` *(fails: No module named 'smolagents')*

------
https://chatgpt.com/codex/tasks/task_e_684047a395b48320a3c380ae5be1b0dc